### PR TITLE
TASK: Indent base_uri in README example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,7 @@ modules:
               - '--disable-dev-shm-usage'
               - '--no-sandbox'
       - PunktDe\Codeception\Mailhog\Module\Mailhog:
-        base_uri: http://mailhog.project
+          base_uri: http://mailhog.project
 ```
 
 


### PR DESCRIPTION
Yaml is very sensitive when it comes to the correct syntax and therefore the existing example did not work in my setup.

- ddev version v1.17.1
- `codeception/codeception`: 4.1.22